### PR TITLE
Admin URLs

### DIFF
--- a/wishlist/adminapp/urls.py
+++ b/wishlist/adminapp/urls.py
@@ -1,0 +1,10 @@
+from . import views
+from django.urls import path
+
+urlpatterns = [
+    path('', views.adminLogin, name='admin-login'),
+    path('home/', views.adminHome, name='admin-home'),
+    path('add/', views.adminAdd, name='admin-add'),
+    path('delete/', views.adminDelete, name='admin-delete'),
+    path('update/', views.adminUpdate, name='admin-update'),
+]

--- a/wishlist/wishlist/urls.py
+++ b/wishlist/wishlist/urls.py
@@ -17,6 +17,6 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path('admin/', include('adminapp.urls')),
     path('wishlist/', include('wishlistapp.urls'))
 ]


### PR DESCRIPTION
Adding the URLs for the admin features. Serving as a skeleton for the admin feature branches. Also, removed the default Django admin site page.